### PR TITLE
Fix format of download duration

### DIFF
--- a/lib/dialogs/pull_model.dart
+++ b/lib/dialogs/pull_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import 'package:open_local_ui/helpers/http.dart';
@@ -27,12 +28,14 @@ class _PullModelDialogState extends State<PullModelDialog> {
 
       final duration = HTTPHelpers.calculateRemainingTime(response);
 
+      final fmt = NumberFormat('#00');
+
       _progressBarText =
           AppLocalizations.of(context)!.progressBarStatusTextWithTimeShared(
         response.status,
-        (duration.inHours).toString(),
-        (duration.inMinutes % 60).toString(),
-        (duration.inSeconds % 60).toString(),
+        fmt.format(duration.inHours),
+        fmt.format(duration.inMinutes % 60),
+        fmt.format(duration.inSeconds % 60),
       );
     });
   }


### PR DESCRIPTION
Format estimated download duration as "00:00:00"
When downloading a model the progress bar shows the remaining time. Currently it is displayed as 0:9:12
With the fix it is displayed as 00:09:12 

This also improves the UI and the dialog is not flickering anymore as its size does not change all the time.
