### PR TITLE
Update the application metadata

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "open_local_ui")
+set(BINARY_NAME "open-local-ui")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.open_local_ui")
+set(APPLICATION_ID "com.github.open_local_ui")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "open_local_ui");
+    gtk_header_bar_set_title(header_bar, "OpenLocalUI");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "open_local_ui");
+    gtk_window_set_title(window, "OpenLocalUI");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.openLocalUi.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.open_local_ui.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_local_ui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_local_ui";
@@ -399,7 +399,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.openLocalUi.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.open_local_ui.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_local_ui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_local_ui";
@@ -413,7 +413,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.openLocalUi.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.openLocalUi.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_local_ui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_local_ui";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = open_local_ui
+PRODUCT_NAME = OpenLocalUI
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.openLocalUi
+PRODUCT_BUNDLE_IDENTIFIER = com.github.open_local_ui
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2024 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2024 WilliamKarolDiCioccio and contributors. All rights reserved.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(open_local_ui LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "open_local_ui")
+set(BINARY_NAME "OpenLocalUI")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "open_local_ui" "\0"
+            VALUE "CompanyName", "OpenLocalUI" "\0"
+            VALUE "FileDescription", "OpenLocalUI Desktop Client" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "open_local_ui" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2024 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "open_local_ui.exe" "\0"
-            VALUE "ProductName", "open_local_ui" "\0"
+            VALUE "InternalName", "OpenLocalUI" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2024 WilliamKarolDiCioccio and contributors. All rights reserved." "\0"
+            VALUE "OriginalFilename", "OpenLocalUI.exe" "\0"
+            VALUE "ProductName", "OpenLocalUI" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -29,7 +29,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"open_local_ui", origin, size)) {
+  if (!window.Create(L"OpenLocalUI", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
Updated for all platforms the app name, binary name and ids. 
Changed from "com.example" to "com.github." for all places.

**Windows:**
The binary will now be "OpenLocalUI.exe"
The window title and task bar will now display it as "OpenLocalUI"
The Taskmanagere will display it as "OpenLocalUI Desktop Client"
The settings will be stored now in "C:\Users\username\AppData\Roaming\OpenLocalUI\OpenLocalUI\"
(the first is the CompanyName the second the AppName). We could pick a different company name if you like.

**Linux (Tested in WSL)** 
The binary name is now "open-local-ui"
The window title is now "OpenLocalUI"
The settings are stored in: ~/.local/share/com.github.open_local_ui/

**MacOS**
Not tested as I have no Mac.

