### PR TITLE
Remove vs code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ untranslated_messages.json
 
 # Environment variable file
 .env*
+
+# Ignore local VS Code settings
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.fontSize": 22,
-    "workbench.iconTheme": "vscode-icons"
-}


### PR DESCRIPTION
Remove VS Code settings file and add it to gitignore
Always after checking out I need to fix my VS Code settings. I think we should not have "project specific" settings in the 
repo. The settings contain an Icon set that I do not have. The font size of 22 is also super large as I do not have a 4K monitor.

