### PR TITLE
Navigate to chat when session is selected

### DIFF
--- a/app/lib/layout/dashboard.dart
+++ b/app/lib/layout/dashboard.dart
@@ -138,7 +138,7 @@ class _DashboardLayoutState extends State<DashboardLayout> {
       children: [
         const ChatPage(),
         SessionsPage(pageController: _pageController),
-        const ModelsPage(),
+        ModelsPage(pageController: _pageController),
         const SettingsPage(),
         const AboutPage(),
       ],

--- a/app/lib/layout/dashboard.dart
+++ b/app/lib/layout/dashboard.dart
@@ -135,16 +135,18 @@ class _DashboardLayoutState extends State<DashboardLayout> {
     return PageView(
       controller: _pageController,
       physics: const NeverScrollableScrollPhysics(),
-      children: const [
-        ChatPage(),
-        SessionsPage(),
-        ModelsPage(),
-        SettingsPage(),
-        AboutPage(),
+      children: [
+        const ChatPage(),
+        SessionsPage(pageController: _pageController),
+        const ModelsPage(),
+        const SettingsPage(),
+        const AboutPage(),
       ],
     );
   }
 }
+
+enum PageIndex { chat, sessions, models, settings, about }
 
 class FeedbackButton extends StatelessWidget {
   const FeedbackButton({super.key});

--- a/app/lib/pages/models.dart
+++ b/app/lib/pages/models.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:open_local_ui/layout/dashboard.dart';
 import 'package:provider/provider.dart';
 import 'package:unicons/unicons.dart';
 
@@ -17,7 +18,9 @@ import 'package:open_local_ui/providers/chat.dart';
 import 'package:open_local_ui/providers/model.dart';
 
 class ModelsPage extends StatefulWidget {
-  const ModelsPage({super.key});
+  final PageController pageController;
+
+  const ModelsPage({super.key, required this.pageController});
 
   @override
   State<ModelsPage> createState() => _ModelsPageState();
@@ -27,7 +30,7 @@ class _ModelsPageState extends State<ModelsPage> {
   @override
   void initState() {
     super.initState();
-    
+
     context.read<ModelProvider>().updateList();
   }
 
@@ -134,24 +137,27 @@ class _ModelsPageState extends State<ModelsPage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
-            tooltip: AppLocalizations.of(context)!.modelsPageDeleteButton,
-            icon: const Icon(UniconsLine.trash),
-            onPressed: () {
-              showConfirmationDialog(
-                context: context,
-                title: AppLocalizations.of(context)!.modelsPageDeleteDialogTitle,
-                content: AppLocalizations.of(context)!.modelsPageDeleteDialogText(model.name),
-                onConfirm: () => _deleteModel(model.name),
-              );
-            },
-          ),
-          IconButton(
             tooltip: AppLocalizations.of(context)!.modelsPageUseButton,
             icon: const Icon(UniconsLine.enter),
             onPressed: () {
               context.read<ChatProvider>().setModel(model.name);
               final session = context.read<ChatProvider>().addSession('');
               context.read<ChatProvider>().setSession(session.uuid);
+              widget.pageController.jumpToPage(PageIndex.chat.index);
+            },
+          ),
+          IconButton(
+            tooltip: AppLocalizations.of(context)!.modelsPageDeleteButton,
+            icon: const Icon(UniconsLine.trash),
+            onPressed: () {
+              showConfirmationDialog(
+                context: context,
+                title:
+                    AppLocalizations.of(context)!.modelsPageDeleteDialogTitle,
+                content: AppLocalizations.of(context)!
+                    .modelsPageDeleteDialogText(model.name),
+                onConfirm: () => _deleteModel(model.name),
+              );
             },
           ),
         ],

--- a/app/lib/pages/sessions.dart
+++ b/app/lib/pages/sessions.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:open_local_ui/dialogs/confirmation.dart';
+import 'package:open_local_ui/layout/dashboard.dart';
 import 'package:provider/provider.dart';
 import 'package:unicons/unicons.dart';
 
@@ -12,7 +13,9 @@ import 'package:open_local_ui/models/chat_session.dart';
 import 'package:open_local_ui/providers/chat.dart';
 
 class SessionsPage extends StatefulWidget {
-  const SessionsPage({super.key});
+  final PageController pageController;
+
+  const SessionsPage({super.key, required this.pageController});
 
   @override
   State<SessionsPage> createState() => _SessionsPageState();
@@ -79,22 +82,25 @@ class _SessionsPageState extends State<SessionsPage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
+            tooltip: AppLocalizations.of(context)!.sessionsPageEnterButton,
+            icon: const Icon(UniconsLine.enter),
+            onPressed: () {
+              context.read<ChatProvider>().setSession(session.uuid);
+              widget.pageController.jumpToPage(PageIndex.chat.index);
+            },
+          ),
+          IconButton(
             tooltip: AppLocalizations.of(context)!.sessionsPageDeleteButton,
             icon: const Icon(UniconsLine.trash),
             onPressed: () {
               showConfirmationDialog(
                 context: context,
-                title: AppLocalizations.of(context)!.sessionsPageDeleteDialogTitle,
-                content: AppLocalizations.of(context)!.sessionsPageDeleteDialogText(session.title),
+                title:
+                    AppLocalizations.of(context)!.sessionsPageDeleteDialogTitle,
+                content: AppLocalizations.of(context)!
+                    .sessionsPageDeleteDialogText(session.title),
                 onConfirm: () => _deleteSession(session.uuid),
               );
-            },
-          ),
-          IconButton(
-            tooltip: AppLocalizations.of(context)!.sessionsPageEnterButton,
-            icon: const Icon(UniconsLine.enter),
-            onPressed: () {
-              context.read<ChatProvider>().setSession(session.uuid);
             },
           ),
         ],


### PR DESCRIPTION
When a session is activated we straight away naviage to the "chat page" so that you can continue chatting in that session.
For this I pass now the pageController into the SessionPage

Additionally I changed the order of the buttons: First the "Enter Session" and then the "Delete". This is more safe as you do not have to move with the mouse over the Delete button to reach the Enter button.