### PR TITLE
Do not update state from within dispose method

### DIFF
--- a/app/lib/widgets/chat_message.dart
+++ b/app/lib/widgets/chat_message.dart
@@ -30,8 +30,6 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
 
   @override
   void dispose() {
-    _cancelEditingMessage();
-
     _textEditingController.dispose();
 
     super.dispose();


### PR DESCRIPTION
Do not update state from within dispose method. The widget is destroyed anyway so it does not make sense to update it.
This fixes random framwork errors logged on the console.
The problem here is that mounted == true but the following setState still fails then with a framwork error.
As the widget is destroyed and the TextEditingController too there is no need to clear it. 

Closes #33