### PR TITLE
Keyboard shortcut for "new session"

### DIFF
--- a/app/lib/pages/chat.dart
+++ b/app/lib/pages/chat.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:open_local_ui/layout/page_base.dart';
 import 'package:open_local_ui/providers/chat.dart';
 import 'package:open_local_ui/widgets/chat_example_questions.dart';
@@ -21,22 +22,28 @@ class ChatPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PageBaseLayout(
-      body: Column(
-        children: [
-          const ChatToolbarWidget(),
-          const SizedBox(height: 16.0),
-          Expanded(
-            child: FractionallySizedBox(
-              widthFactor: 0.6,
-              child: _buildInnerWidget(context),
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.keyN, control: true):
+            context.read<ChatProvider>().newSession,
+      },
+      child: PageBaseLayout(
+        body: Column(
+          children: [
+            const ChatToolbarWidget(),
+            const SizedBox(height: 16.0),
+            Expanded(
+              child: FractionallySizedBox(
+                widthFactor: 0.6,
+                child: _buildInnerWidget(context),
+              ),
             ),
-          ),
-          const FractionallySizedBox(
-            widthFactor: 0.6,
-            child: ChatInputFieldWidget(),
-          ),
-        ],
+            const FractionallySizedBox(
+              widthFactor: 0.6,
+              child: ChatInputFieldWidget(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/providers/chat.dart
+++ b/app/lib/providers/chat.dart
@@ -466,6 +466,12 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void newSession() {
+    final session = addSession('');
+    setSession(session.uuid);
+    notifyListeners();
+  }
+
   bool get isWebSearchEnabled => _enableWebSearch;
 
   bool get isDocsSearchEnabled => _enableDocsSearch;

--- a/app/lib/widgets/chat_toolbar.dart
+++ b/app/lib/widgets/chat_toolbar.dart
@@ -30,8 +30,7 @@ class _ChatToolbarWidgetState extends State<ChatToolbarWidget> {
           SnackBarType.error,
         );
       } else {
-        final session = context.read<ChatProvider>().addSession('');
-        context.read<ChatProvider>().setSession(session.uuid);
+        context.read<ChatProvider>().newSession();
       }
     } else {
       SnackBarHelper.showSnackBar(


### PR DESCRIPTION
Implement a keyboard shortcut CTRL+N to start a new session.
This works when you are on the chat screen. For this I:
- moved the logic to start a fresh session into the chat provider
- Added CallbackShortcuts to the Chat page
- Adapted the New Session button to call the new method in the Chat provider

