### PR TITLE
Improve styling of inline code blocks in dark mode

### DIFF
--- a/app/lib/widgets/markdown_widget.dart
+++ b/app/lib/widgets/markdown_widget.dart
@@ -63,6 +63,12 @@ class MessageMarkdownWidget extends StatelessWidget {
           const H5Config(style: header5TextStyle),
           const H6Config(style: header6TextStyle),
           const PConfig(textStyle: paragraphTextStyle),
+          if (isDark)
+            CodeConfig(
+              style: codeTextStyle.copyWith(
+                backgroundColor: const Color.fromARGB(204, 46, 46, 46),
+              ),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
Added a config for inline code blocks. Set the code font and a better background color.
Found out that we can set a config for this independent of real code blocks.

Fixes #44  