### PR TITLE
Show Flutter license page instead

### DIFF
--- a/app/LICENSE
+++ b/app/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 William Karol Di Cioccio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/lib/layout/dashboard.dart
+++ b/app/lib/layout/dashboard.dart
@@ -14,7 +14,6 @@ import 'package:open_local_ui/pages/models.dart';
 import 'package:open_local_ui/pages/sessions.dart';
 import 'package:open_local_ui/pages/settings.dart';
 import 'package:unicons/unicons.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class DashboardLayout extends StatefulWidget {
   const DashboardLayout({super.key});
@@ -255,11 +254,7 @@ class LicenseButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextButton.icon(
       onPressed: () {
-        launchUrl(
-          Uri.parse(
-            'https://github.com/WilliamKarolDiCioccio/open_local_ui/blob/main/LICENSE.md',
-          ),
-        );
+        showLicensePage(context: context);
       },
       icon: const Icon(UniconsLine.keyhole_circle),
       label: Text(AppLocalizations.of(context)!.licenseButton),


### PR DESCRIPTION
Instead of jumping to the webpage show the standard Flutter license page.
This one automatically collects all the licenses of all used packages and displays them on a standard page.
The advantage is that it fullfills all legal requirements to include copies of the licenses and make them available to the end user.

For this to work and to include our license you need to have a file named **LICENSE** in the app root folder.
So I copied the **LICENSE.md** from the project root into the **app** folder.

The downside is that the license of the App itself is somewhere in the sorted list as "open_local_ui"
so it is a little bit hard to find.