### PR TITLE
Display token statistics in Chat

### DIFF
--- a/app/lib/l10n/arb/intl_en.arb
+++ b/app/lib/l10n/arb/intl_en.arb
@@ -245,6 +245,7 @@
   "settingsPageOllamaLabel": "Ollama",
   "settingsPageOllamaTemperatureLabel": "Set temperature",
   "settingsPageOllamaUseGPULabel": "Use GPU",
+  "settingsPageOllamaShowStatistics": "Show Statistics",
   "settingsPageThemeLabel": "Theme",
   "settingsPageTitle": "Settings",
   "settingsThemeModeDark": "Dark",

--- a/app/lib/models/chat_message.dart
+++ b/app/lib/models/chat_message.dart
@@ -70,6 +70,19 @@ class ChatMessageWrapper {
   final String uuid;
   final String? senderName;
 
+  // Metadata
+  int totalDuration;
+  int loadDuration;
+  int promptEvalCount;
+  int promptEvalDuration;
+  int evalCount;
+  int evalDuration;
+
+  // Usage
+  int promptTokens;
+  int responseTokens;
+  int totalTokens;
+
   @JsonKey(
     includeToJson: true,
     includeFromJson: true,
@@ -84,6 +97,15 @@ class ChatMessageWrapper {
     this.uuid,
     this.sender, {
     this.senderName,
+    this.totalDuration = 0,
+    this.loadDuration = 0,
+    this.promptEvalCount = 0,
+    this.promptEvalDuration = 0,
+    this.evalCount = 0,
+    this.evalDuration = 0,
+    this.promptTokens = 0,
+    this.responseTokens = 0,
+    this.totalTokens = 0,
   });
 
   factory ChatMessageWrapper.fromJson(Map<String, dynamic> json) =>

--- a/app/lib/pages/settings.dart
+++ b/app/lib/pages/settings.dart
@@ -313,6 +313,24 @@ class _OllamaSettingsState extends State<OllamaSettings> {
                   ),
                 ],
               ),
+              const Gap(16.0),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(UniconsLine.calculator),
+                  const Gap(8.0),
+                  Text(
+                    '${AppLocalizations.of(context).settingsPageOllamaShowStatistics}:',
+                    style: const TextStyle(fontSize: 16.0),
+                  ),
+                  const Gap(8.0),
+                  Switch(
+                    value: context.watch<ChatProvider>().isChatShowStatistics,
+                    onChanged: (value) =>
+                        context.read<ChatProvider>().enableStatistics(value),
+                  ),
+                ],
+              ),
             ],
           ),
         ),

--- a/app/lib/widgets/chat_message.dart
+++ b/app/lib/widgets/chat_message.dart
@@ -125,6 +125,8 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     late String senderName;
     late IconData senderIconData;
 
+    final chatProvider = context.watch<ChatProvider>();
+
     switch (widget.message.sender) {
       case ChatMessageSender.user:
         senderIconData = UniconsLine.user;
@@ -205,7 +207,10 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
               const SizedBox(height: 8.0),
           if (!_showEditWidget)
             MessageMarkdownWidget(
-              widget.message.text,
+              widget.message.text +
+                  (chatProvider.isChatShowStatistics
+                      ? _buildStatisticsSummary(widget.message)
+                      : ''),
             ),
           const Gap(8.0),
           if (!_showEditWidget && !_showPlayerWidget)
@@ -293,5 +298,21 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
         ],
       ),
     );
+  }
+
+  String _buildStatisticsSummary(ChatMessageWrapper message) {
+    if (message.totalTokens == 0) {
+      return '';
+    }
+
+    final token = message.totalTokens;
+    final durationMs = message.totalDuration / 1000 ~/ 1000;
+    final tps = (token / (durationMs / 1000)).toStringAsFixed(2);
+
+    return '''
+
+
+**Token:** $token   **Duration:** $durationMs ms   **Speed:** $tps t/s
+ ''';
   }
 }


### PR DESCRIPTION
Add a setting to the settings page
Store statistics in the ChatMessages
Display statistics in chat widget when turned on in the settings.

The trick was to remove the **StringOutputParser** from the processing chain. Then we get the **ChatReponse** objects directly.
The last one of those contains the statistics. These I store then directly in the **ChatMessage** for later retrieval. 
The Chat widget uses then these statistics to append at the bottom a summary (if activated in the settings). 