### PR TITLE
Change styling of links in markdown

### DIFF
--- a/app/lib/styles/markdown.dart
+++ b/app/lib/styles/markdown.dart
@@ -7,7 +7,6 @@ const codeTextStyle = TextStyle(
 
 const linkTextStyle = TextStyle(
   color: Colors.blue,
-  decoration: TextDecoration.underline,
 );
 
 const header1TextStyle = TextStyle(


### PR DESCRIPTION
Remove underline for links. For me this looks way cleaner.
But you decide ;-)