### PR TITLE
Remove input length limit from message field

### DIFF
--- a/app/lib/widgets/chat_input_field.dart
+++ b/app/lib/widgets/chat_input_field.dart
@@ -138,10 +138,9 @@ class _ChatInputFieldWidgetState extends State<ChatInputFieldWidget> {
             fontWeight: FontWeight.w300,
           ),
           autofocus: true,
-          maxLength: 4096,
+          maxLength: TextField.noMaxLength,
           maxLines: null,
           expands: false,
-          maxLengthEnforcement: MaxLengthEnforcement.enforced,
         ),
       ),
     );


### PR DESCRIPTION
Remove input length limit but still show character count.
As we do not know what context window limits are in place by the currently used model we should not limit the input field.

This change will remove the input limit but still show the "character count" below the text field.