### PR TITLE
Allow jpg file extension for images

### DIFF
--- a/app/lib/dialogs/attachments_dropzone.dart
+++ b/app/lib/dialogs/attachments_dropzone.dart
@@ -164,7 +164,7 @@ class _AttachmentsDropzoneDialogState extends State<AttachmentsDropzoneDialog> {
       allowMultiple: false,
       allowCompression: false,
       type: FileType.custom,
-      allowedExtensions: ['png', 'jpeg', 'webp'],
+      allowedExtensions: ['png', 'jpg', 'jpeg', 'webp'],
     );
 
     if (result != null) {


### PR DESCRIPTION
I was not able to see my pictures im the file chooser because my files have as extension ".jpg"
We need to allow this extension in the file picker too.