### PR TITLE
Write session to file and open it

### DIFF
--- a/app/lib/pages/sessions.dart
+++ b/app/lib/pages/sessions.dart
@@ -14,7 +14,6 @@ import 'package:open_local_ui/models/chat_session.dart';
 import 'package:open_local_ui/providers/chat.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unicons/unicons.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/app/lib/pages/sessions.dart
+++ b/app/lib/pages/sessions.dart
@@ -17,6 +17,7 @@ import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unicons/unicons.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 enum SortBy {
   name,
@@ -303,30 +304,12 @@ class _SessionListTileState extends State<SessionListTile> {
         SnackBarType.error,
       );
     } else {
-      late ShareResult shareResult;
+      final targetDir = (await getDownloadsDirectory())?.path ?? '.';
 
-      if (Platform.isLinux) {
-        shareResult = await Share.share(widget.session.toJson().toString());
-      } else {
-        final cacheDir = await getApplicationCacheDirectory();
-
-        final file = File('${cacheDir.path}/${widget.session.uuid}.json');
-        await file.writeAsString(widget.session.toJson().toString());
-
-        final shareFile = XFile(
-          file.path,
-          mimeType: 'application/json',
-          name: widget.session.title,
-          lastModified: widget.session.messages.last.createdAt,
-        );
-
-        shareResult = await Share.shareXFiles(
-          [shareFile],
-          text: widget.session.title,
-        );
-      }
-
-      if (shareResult.status == ShareResultStatus.success) {
+      final file =
+          File('$targetDir/OpenLocalUI_Chat_${widget.session.uuid}.json');
+      await file.writeAsString(widget.session.toJson().toString());
+      if (await launchUrl(file.uri)) {
         SnackBarHelpers.showSnackBar(
           // ignore: use_build_context_synchronously
           AppLocalizations.of(context).sessionSharedSnackBar,

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,7 +14,6 @@ import irondash_engine_context
 import isar_flutter_libs
 import package_info_plus
 import path_provider_foundation
-import share_plus
 import shared_preferences_foundation
 import sqflite
 import super_native_extensions
@@ -31,7 +30,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1205,22 +1205,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  share_plus:
-    dependency: "direct main"
-    description:
-      name: share_plus
-      sha256: ef3489a969683c4f3d0239010cc8b7a2a46543a8d139e111c06c558875083544
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.0.0"
-  share_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: share_plus_platform_interface
-      sha256: "0f9e4418835d1b2c3ae78fdb918251959106cefdbc4dd43526e182f80e82f6d4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -77,7 +77,6 @@ dependencies:
   url_launcher: ^6.2.6
   
   # Share Plus
-  share_plus: ^9.0.0
 
   # Supabase Integration
   supabase_flutter: ^2.5.2

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -11,7 +11,6 @@
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
-#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <super_native_extensions/super_native_extensions_plugin_c_api.h>
 #include <system_theme/system_theme_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -27,8 +26,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
-  SharePlusWindowsPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   SuperNativeExtensionsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SuperNativeExtensionsPluginCApi"));
   SystemThemePluginRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -8,7 +8,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   bitsdojo_window_windows
   irondash_engine_context
   isar_flutter_libs
-  share_plus
   super_native_extensions
   system_theme
   url_launcher_windows


### PR DESCRIPTION
Share plus does not work great on desktop. Here an alternative approach.
- Write session to json file in "downloads" folder
- Open the file by invoking it as URL 
- System will either open the file or ask you what to do with it

Fixes #49

We could then maybe also remove Share Plus package if it is not used for something else?