### PR TITLE
Change logging dir

### DIFF
--- a/app/lib/core/logger.dart
+++ b/app/lib/core/logger.dart
@@ -29,7 +29,7 @@ Future<File> _createLogFile() async {
 
   final fileName = 'log_$timeStamp.log';
   final directory = await getApplicationSupportDirectory();
-  final logsFolderPath = '${directory.path}/OpenLocalUI/logs';
+  final logsFolderPath = '${directory.path}/logs';
 
   await Directory(logsFolderPath).create(recursive: true);
   final logFile = File('$logsFolderPath/$fileName');


### PR DESCRIPTION
Just a small fix. Remove unnecessary subdirectory. 

Currently the logs are created in 
_C:\Users\myuser\AppData\Roaming\OpenLocalUI\OpenLocalUI\OpenLocalUI\logs_

but they should be in 
_C:\Users\myuser\AppData\Roaming\OpenLocalUI\OpenLocalUI\logs_

