### PR TITLE
Check status before starting ollama process

### DIFF
--- a/app/lib/backend/services/tts.dart
+++ b/app/lib/backend/services/tts.dart
@@ -60,8 +60,12 @@ class TTSService {
       final directory = p.dirname(Platform.resolvedExecutable);
       executablePath = '$directory/server.exe';
     } else {
-      logger.e('Unsupported platform');
+      logger.d('Unsupported platform');
+      return;
+    }
 
+    if (!await File(executablePath).exists()) {
+      logger.d('TTS Server executable not found');
       return;
     }
 

--- a/app/lib/core/github.dart
+++ b/app/lib/core/github.dart
@@ -90,7 +90,7 @@ class GitHubAPI {
     final response = await http.get(url, headers: headers);
 
     if (response.statusCode != 200) {
-      logger.e(
+      logger.d(
         'Failed to get latest release. Status code: ${response.statusCode}',
       );
 
@@ -167,7 +167,7 @@ class GitHubAPI {
 // @formatter:off
     if (defaultTargetPlatform == TargetPlatform.windows) {
       final plugin = await DeviceInfoPlugin().windowsInfo;
-deviceInfo = '''
+      deviceInfo = '''
 - Platfrom: ${plugin.productName}
 - Major version: ${plugin.majorVersion}
 - Minor version: ${plugin.minorVersion}
@@ -199,7 +199,7 @@ deviceInfo = '''
     final packageInfo = await PackageInfo.fromPlatform();
 
 // @formatter:off
-final issueTextBody = '''
+    final issueTextBody = '''
 $text
 \n
 \n


### PR DESCRIPTION
Improved a little bit the logging. Everytime I start from VS Code I see some errors on the console. To prevent this I added some additional checks.
Check if ollama is already running before we try to start it
Check if server.exe exists before we start the tts server
Log only as debug and not as error in this scenario.