### PR TITLE
Update scroll button position when size changes

### DIFF
--- a/app/lib/frontend/widgets/chat_message_list.dart
+++ b/app/lib/frontend/widgets/chat_message_list.dart
@@ -90,6 +90,9 @@ class _ChatMessageListState extends State<ChatMessageList> {
       _scrollToBottom();
     }
 
+    // Listen for screen resizing to update the scroll button position
+    MediaQuery.of(context);
+
     return Column(
       children: [
         Expanded(


### PR DESCRIPTION
Update scroll button position when size changes. To detect this we watch the MediaQuery.

This fixes #46 but not perfectly.  The button updates its position now when you resize the window.
The problem is that when you resize the window quickly the button is "one frame behind" as the calculation is based on the render box which is then not yet up to date.